### PR TITLE
OS X 10.8.4 plugin compatibility

### DIFF
--- a/UniversalMailer/UniversalMailer-Info.plist
+++ b/UniversalMailer/UniversalMailer-Info.plist
@@ -47,6 +47,8 @@
 		<string>E71BD599-351A-42C5-9B63-EA5C47F7CE8E</string>
 		<string>EF59EC5E-EFCD-4EA7-B617-6C5708397D24</string>
 		<string>4C286C70-7F18-4839-B903-6F2D58FA4C71</string>
+		<string>19B53E95-0964-4AAB-88F9-6D2F8B7B6037</string>
+		<string>2183B2CD-BEDF-4AA6-AC18-A1BBED2E3354</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Added the new SupportedPluginCompatibilityUUIDs to make it work with OS X 10.8.4 Mail.
