### PR TITLE
Add UUIDs for 10.9.2-10.9.4.

### DIFF
--- a/UniversalMailer Tests/UniversalMailer Tests-Info.plist
+++ b/UniversalMailer Tests/UniversalMailer Tests-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>it.noware.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/UniversalMailer.xcodeproj/project.pbxproj
+++ b/UniversalMailer.xcodeproj/project.pbxproj
@@ -582,7 +582,7 @@
 		81885EEF177336930080892C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = noware;
 				TargetAttributes = {
 					81146A451775C8D40067B93D = {
@@ -774,6 +774,7 @@
 		81146A551775C8D40067B93D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"$(inherited)",
@@ -786,6 +787,7 @@
 				);
 				HEADER_SEARCH_PATHS = "\"$SRCROOT\"";
 				INFOPLIST_FILE = "UniversalMailer Tests/UniversalMailer Tests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "it.noware.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = xctest;
 			};
@@ -794,6 +796,7 @@
 		81146A561775C8D40067B93D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"$(inherited)",
@@ -802,6 +805,7 @@
 				GCC_PREFIX_HEADER = "UniversalMailer Tests/UniversalMailer Tests-Prefix.pch";
 				HEADER_SEARCH_PATHS = "\"$SRCROOT\"";
 				INFOPLIST_FILE = "UniversalMailer Tests/UniversalMailer Tests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "it.noware.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = xctest;
 			};
@@ -838,6 +842,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -918,6 +923,7 @@
 					"-DHAVE_MIMETIC_CONFIG",
 					"-DDEBUG",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "it.noware.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = mailbundle;
 			};
@@ -937,6 +943,7 @@
 				INFOPLIST_FILE = "UniversalMailer/UniversalMailer-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
 				OTHER_CFLAGS = "-DHAVE_MIMETIC_CONFIG";
+				PRODUCT_BUNDLE_IDENTIFIER = "it.noware.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = mailbundle;
 			};

--- a/UniversalMailer/UniversalMailer-Info.plist
+++ b/UniversalMailer/UniversalMailer-Info.plist
@@ -32,6 +32,7 @@
 		<string>F4C26776-22B3-4A0A-96E1-EA8E4482E0B5</string>
 		<string>88ED2D4C-D384-4BF5-8E94-B533455E6AAF</string>
 		<string>1CD40D64-945D-4D50-B12D-9CD865533506</string>
+		<string>DAF41AB7-F9AD-4273-9934-C81C74705B69</string>
 	</array>
 </dict>
 </plist>

--- a/UniversalMailer/UniversalMailer-Info.plist
+++ b/UniversalMailer/UniversalMailer-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>it.noware.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/UniversalMailer/UniversalMailer-Info.plist
+++ b/UniversalMailer/UniversalMailer-Info.plist
@@ -28,6 +28,9 @@
 	<string>UniversalMailer</string>
 	<key>SupportedPluginCompatibilityUUIDs</key>
 	<array>
+		<string>D1EFE124-86FF-4751-BF00-80B2C0D6F2E4</string>
+		<string>F4C26776-22B3-4A0A-96E1-EA8E4482E0B5</string>
+		<string>88ED2D4C-D384-4BF5-8E94-B533455E6AAF</string>
 		<string>1CD40D64-945D-4D50-B12D-9CD865533506</string>
 	</array>
 </dict>

--- a/mimetic/parser/itparser.h
+++ b/mimetic/parser/itparser.h
@@ -234,7 +234,7 @@ protected:
             sValue,
             sIgnoreHeader
         };
-        register int status;
+        int status;
         int pos;
         char *name, *value;
         size_t nBufSz, vBufSz, nPos, vPos;
@@ -472,7 +472,7 @@ protected:
     virtual void copy_until_boundary(ParsingElem pe)
     {
         size_t pos, lines, eomsz = 0;
-        register char c;
+        char c;
         enum { nlsz = 1 };
         const char *eom = 0;
 


### PR DESCRIPTION
Please consider this trivial update to SupportedPluginCompatibilityUUIDs to allow the plugin to work with newer versions of Mail.app.