### PR TITLE
Updated to Yosemite DP7

### DIFF
--- a/UniversalMailer/UniversalMailer-Info.plist
+++ b/UniversalMailer/UniversalMailer-Info.plist
@@ -29,6 +29,7 @@
 	<key>SupportedPluginCompatibilityUUIDs</key>
 	<array>
 		<string>1CD40D64-945D-4D50-B12D-9CD865533506</string>
+<string>21599536-7086-449D-B777-B2880FC27F86</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This is to maintain compatibility with the latest Apple Mail 8 in Yosemite DP 7. Tested quickly, all good so far.